### PR TITLE
Version 1.10.0

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -937,7 +937,7 @@ func isSmartUsageAvailable() bool {
 
 // showBasicUsage prints basic usage info
 func showBasicUsage() {
-	if options.GetB(OPT_PAGER) {
+	if options.GetB(OPT_PAGER) || prefs.AutoPaging {
 		if pager.Setup() == nil {
 			defer pager.Complete()
 		}
@@ -957,7 +957,7 @@ func showSmartUsage() {
 	isSentinelFailover := CORE.IsFailoverMethod(CORE.FAILOVER_METHOD_SENTINEL)
 	allowCommands := CORE.Config.GetB(CORE.REPLICATION_ALLOW_COMMANDS)
 
-	if options.GetB(OPT_PAGER) {
+	if options.GetB(OPT_PAGER) || prefs.AutoPaging {
 		if pager.Setup() == nil {
 			defer pager.Complete()
 		}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -45,7 +45,7 @@ import (
 
 const (
 	APP  = "RDS"
-	VER  = "1.9.1"
+	VER  = "1.10.0"
 	DESC = "Tool for Redis orchestration"
 )
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -45,7 +45,7 @@ import (
 
 const (
 	APP  = "RDS"
-	VER  = "1.9.0"
+	VER  = "1.9.1"
 	DESC = "Tool for Redis orchestration"
 )
 

--- a/cli/command_clients.go
+++ b/cli/command_clients.go
@@ -67,7 +67,7 @@ func ClientsCommand(args CommandArgs) int {
 		return EC_ERROR
 	}
 
-	if options.GetB(OPT_PAGER) && !useRawOutput {
+	if (options.GetB(OPT_PAGER) || prefs.AutoPaging) && !useRawOutput {
 		if pager.Setup() == nil {
 			defer pager.Complete()
 		}

--- a/cli/command_conf.go
+++ b/cli/command_conf.go
@@ -79,7 +79,7 @@ func ConfCommand(args CommandArgs) int {
 		diff = REDIS.GetConfigsDiff(fileConfig, memConfig)
 	}
 
-	if options.GetB(OPT_PAGER) && !useRawOutput {
+	if (options.GetB(OPT_PAGER) || prefs.AutoPaging) && !useRawOutput {
 		if pager.Setup() == nil {
 			defer pager.Complete()
 		}

--- a/cli/command_help.go
+++ b/cli/command_help.go
@@ -124,7 +124,7 @@ func HelpCommand(args CommandArgs) int {
 		return EC_ERROR
 	}
 
-	if options.GetB(OPT_PAGER) {
+	if options.GetB(OPT_PAGER) || prefs.AutoPaging {
 		if pager.Setup() == nil {
 			defer pager.Complete()
 		}

--- a/cli/command_info.go
+++ b/cli/command_info.go
@@ -76,7 +76,7 @@ func InfoCommand(args CommandArgs) int {
 		sections = getCorrectedSections(args[1:])
 	}
 
-	if options.GetB(OPT_PAGER) && !useRawOutput {
+	if (options.GetB(OPT_PAGER) || prefs.AutoPaging) && !useRawOutput {
 		if pager.Setup() == nil {
 			defer pager.Complete()
 		}

--- a/cli/command_info.go
+++ b/cli/command_info.go
@@ -192,7 +192,7 @@ func showInstanceBasicInfo(t *table.Table, id int, info *REDIS.Info, state CORE.
 	redisVersionInfo := ""
 	currentRedisVer, err := CORE.GetRedisVersion()
 
-	if err != nil && currentRedisVer.String() != "" {
+	if err == nil && currentRedisVer.String() != "" {
 		redisVersionInfo = "(current: " + currentRedisVer.String() + ")"
 	}
 

--- a/cli/command_list.go
+++ b/cli/command_list.go
@@ -60,7 +60,7 @@ func ListCommand(args CommandArgs) int {
 		)
 	}
 
-	if options.GetB(OPT_PAGER) && !useRawOutput {
+	if (options.GetB(OPT_PAGER) || prefs.AutoPaging) && !useRawOutput {
 		if pager.Setup() == nil {
 			defer pager.Complete()
 		}

--- a/cli/command_memory.go
+++ b/cli/command_memory.go
@@ -56,7 +56,7 @@ func MemoryCommand(args CommandArgs) int {
 		return EC_ERROR
 	}
 
-	if options.GetB(OPT_PAGER) && !useRawOutput {
+	if (options.GetB(OPT_PAGER) || prefs.AutoPaging) && !useRawOutput {
 		if pager.Setup() == nil {
 			defer pager.Complete()
 		}

--- a/cli/command_memory.go
+++ b/cli/command_memory.go
@@ -90,7 +90,7 @@ func printMemoryUsage(metrics []instanceMemoryMetric) {
 		case strutil.HasPrefixAny(m.Field, "allocator.", "clients.", "replication.", "aof.", "lua.", "cluster."),
 			strutil.HasSuffixAny(m.Field, ".bytes", ".allocated", ".bytes-per-key"):
 			t.Add(m.Field, fmtc.Sprintf("%s {s}(%s){!}",
-				fmtutil.PrettySize(m.Value), fmtutil.PrettyNum(m.Value),
+				fmtutil.PrettySize(m.Value.(int)), fmtutil.PrettyNum(m.Value),
 			))
 
 		default:

--- a/cli/command_sentinel.go
+++ b/cli/command_sentinel.go
@@ -205,7 +205,7 @@ func SentinelInfoCommand(args CommandArgs) int {
 		return EC_ERROR
 	}
 
-	if options.GetB(OPT_PAGER) && !useRawOutput {
+	if (options.GetB(OPT_PAGER) || prefs.AutoPaging) && !useRawOutput {
 		if pager.Setup() == nil {
 			defer pager.Complete()
 		}

--- a/cli/command_settings.go
+++ b/cli/command_settings.go
@@ -42,7 +42,7 @@ func SettingsCommand(args CommandArgs) int {
 
 // printAllSettings prints all settings
 func printAllSettings() int {
-	if options.GetB(OPT_PAGER) && !useRawOutput {
+	if (options.GetB(OPT_PAGER) || prefs.AutoPaging) && !useRawOutput {
 		if pager.Setup() == nil {
 			defer pager.Complete()
 		}

--- a/cli/command_slowlog.go
+++ b/cli/command_slowlog.go
@@ -53,7 +53,7 @@ func SlowlogGetCommand(args CommandArgs) int {
 		}
 	}
 
-	if options.GetB(OPT_PAGER) && !useRawOutput {
+	if (options.GetB(OPT_PAGER) || prefs.AutoPaging) && !useRawOutput {
 		if pager.Setup() == nil {
 			defer pager.Complete()
 		}

--- a/cli/command_stats.go
+++ b/cli/command_stats.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/essentialkaos/ek/v12/fmtc"
 	"github.com/essentialkaos/ek/v12/fmtutil"
+	"github.com/essentialkaos/ek/v12/mathutil"
 	"github.com/essentialkaos/ek/v12/options"
 	"github.com/essentialkaos/ek/v12/terminal"
 
@@ -89,12 +90,25 @@ func renderStats(stats *CORE.Stats) {
 	fmtc.Println(" ▾ {*}MEMORY{!}")
 	fmtutil.Separator(true)
 
-	renderStatsValue("System Memory", stats.Memory.SystemMemory, true)
+	renderStatsValue("Total System Memory", stats.Memory.TotalSystemMemory, true)
+	fmtc.Printf(
+		" %-26s {s}|{!} %s {s-}(%s ~ %s){!}\n", "System Memory",
+		fmtutil.PrettyNum(stats.Memory.SystemMemory),
+		fmtutil.PrettySize(stats.Memory.SystemMemory),
+		fmtutil.PrettyPerc(mathutil.Perc(stats.Memory.SystemMemory, stats.Memory.TotalSystemMemory)),
+	)
 
 	switch stats.Memory.IsSwapEnabled {
 	case true:
-		renderStatsValue("System Swap", stats.Memory.SystemSwap, true)
+		renderStatsValue("Total System Swap", stats.Memory.TotalSystemSwap, true)
+		fmtc.Printf(
+			" %-26s {s}|{!} %s {s-}(%s ~ %s){!}\n", "System Swap",
+			fmtutil.PrettyNum(stats.Memory.SystemSwap),
+			fmtutil.PrettySize(stats.Memory.SystemSwap),
+			fmtutil.PrettyPerc(mathutil.Perc(stats.Memory.SystemSwap, stats.Memory.TotalSystemSwap)),
+		)
 	default:
+		fmtc.Printf(" %-26s {s}|{!} {s}—{!} {s-}(disabled){!}\n", "Total System Swap")
 		fmtc.Printf(" %-26s {s}|{!} {s}—{!} {s-}(disabled){!}\n", "System Swap")
 	}
 
@@ -150,7 +164,9 @@ func renderStatsAsText(stats *CORE.Stats) {
 	fmt.Println("outdated_instances", stats.Instances.Outdated)
 	fmt.Println("connected_clients", stats.Clients.Connected)
 	fmt.Println("blocked_clients", stats.Clients.Blocked)
+	fmt.Println("total_system_memory", stats.Memory.TotalSystemMemory)
 	fmt.Println("system_memory", stats.Memory.SystemMemory)
+	fmt.Println("total_system_swap", stats.Memory.TotalSystemSwap)
 	fmt.Println("system_swap", stats.Memory.SystemSwap)
 	fmt.Println("used_memory", stats.Memory.UsedMemory)
 	fmt.Println("used_memory_rss", stats.Memory.UsedMemoryRSS)
@@ -196,7 +212,9 @@ func renderStatsAsXML(stats *CORE.Stats) {
 	fmt.Println("  </clients>")
 
 	fmt.Println("  <memory>")
+	renderStatsAsXMLValue("total_system_memory", stats.Memory.TotalSystemMemory)
 	renderStatsAsXMLValue("system_memory", stats.Memory.SystemMemory)
+	renderStatsAsXMLValue("total_system_swap", stats.Memory.TotalSystemSwap)
 	renderStatsAsXMLValue("system_swap", stats.Memory.SystemSwap)
 	renderStatsAsXMLValue("used_memory", stats.Memory.UsedMemory)
 	renderStatsAsXMLValue("used_memory_rss", stats.Memory.UsedMemoryRSS)
@@ -230,7 +248,6 @@ func renderStatsAsXML(stats *CORE.Stats) {
 // renderStatsAsJSON print stats data as json
 func renderStatsAsJSON(stats *CORE.Stats) {
 	jd, _ := json.MarshalIndent(stats, "", "  ")
-
 	fmt.Println(string(jd))
 }
 
@@ -242,7 +259,7 @@ func renderStatsAsXMLValue(name string, value uint64) {
 // renderStatsValue print stats property for pretty output
 func renderStatsValue(name string, value uint64, isSize bool) {
 	if isSize {
-		fmtc.Printf(" %-26s {s}|{!} %s\n", name, fmtc.Sprintf("%s {s-}(%s){!}", fmtutil.PrettyNum(value), fmtutil.PrettySize(int64(value))))
+		fmtc.Printf(" %-26s {s}|{!} %s {s-}(%s){!}\n", name, fmtutil.PrettyNum(value), fmtutil.PrettySize(value))
 	} else {
 		fmtc.Printf(" %-26s {s}|{!} %s\n", name, fmtutil.PrettyNum(value))
 	}

--- a/cli/command_stats_command.go
+++ b/cli/command_stats_command.go
@@ -51,7 +51,7 @@ func StatsCommandCommand(args CommandArgs) int {
 		return EC_ERROR
 	}
 
-	if options.GetB(OPT_PAGER) && !useRawOutput {
+	if (options.GetB(OPT_PAGER) || prefs.AutoPaging) && !useRawOutput {
 		if pager.Setup() == nil {
 			defer pager.Complete()
 		}

--- a/cli/command_stats_error.go
+++ b/cli/command_stats_error.go
@@ -48,7 +48,7 @@ func StatsErrorCommand(args CommandArgs) int {
 		return EC_ERROR
 	}
 
-	if options.GetB(OPT_PAGER) && !useRawOutput {
+	if (options.GetB(OPT_PAGER) || prefs.AutoPaging) && !useRawOutput {
 		if pager.Setup() == nil {
 			defer pager.Complete()
 		}

--- a/cli/command_stats_latency.go
+++ b/cli/command_stats_latency.go
@@ -47,7 +47,7 @@ func StatsLatencyCommand(args CommandArgs) int {
 		return EC_ERROR
 	}
 
-	if options.GetB(OPT_PAGER) && !useRawOutput {
+	if (options.GetB(OPT_PAGER) || prefs.AutoPaging) && !useRawOutput {
 		if pager.Setup() == nil {
 			defer pager.Complete()
 		}

--- a/cli/command_top.go
+++ b/cli/command_top.go
@@ -83,7 +83,7 @@ func TopCommand(args CommandArgs) int {
 		sort.Sort(items)
 	}
 
-	if options.GetB(OPT_PAGER) && !useRawOutput {
+	if (options.GetB(OPT_PAGER) || prefs.AutoPaging) && !useRawOutput {
 		if pager.Setup() == nil {
 			defer pager.Complete()
 		}
@@ -174,7 +174,7 @@ func TopDiffCommand(args CommandArgs) int {
 		return EC_ERROR
 	}
 
-	if options.GetB(OPT_PAGER) && !useRawOutput {
+	if (options.GetB(OPT_PAGER) || prefs.AutoPaging) && !useRawOutput {
 		if pager.Setup() == nil {
 			defer pager.Complete()
 		}

--- a/cli/preferences.go
+++ b/cli/preferences.go
@@ -21,6 +21,7 @@ type Preferences struct {
 	DisableTips     bool
 	EnablePowerline bool
 	SimpleUI        bool
+	AutoPaging      bool
 }
 
 // ////////////////////////////////////////////////////////////////////////////////// //
@@ -56,5 +57,6 @@ func readUserPreferences(user string) Preferences {
 		DisableTips:     prefsCfg.GetB("cli:disable-tips", false),
 		EnablePowerline: prefsCfg.GetB("cli:enable-powerline", false),
 		SimpleUI:        prefsCfg.GetB("cli:simple-ui", false),
+		AutoPaging:      prefsCfg.GetB("cli:auto-paging", false),
 	}
 }

--- a/cli/tips.go
+++ b/cli/tips.go
@@ -296,6 +296,14 @@ with {?opt}-x{!}/{?opt}--extra{!} option:
 
 {?more}More information: sudo rds help log{!}`,
 		},
+		&protip.Tip{
+			Title: `User-specific preferences`,
+			Message: `RDS users can set their own preferences using a configuration file stored in their
+home directory. It can be used to disable ProTips, enable Powerline font support,
+enable a simplified user interface, or enable automatic paging for long output.
+
+{?more}More information: {_}https://kaos.sh/rds/w/User-preferences{!}`,
+		},
 	)
 
 	return protip.Show(false)

--- a/common/preferencies.knf
+++ b/common/preferencies.knf
@@ -10,3 +10,6 @@
 
   # Simplify user interface by default
   simple-ui: false
+
+  # Enable pager for long output
+  auto-paging: false

--- a/common/rds.spec
+++ b/common/rds.spec
@@ -188,6 +188,7 @@ systemctl daemon-reload &>/dev/null || :
 %changelog
 * Tue Jan 23 2024 Anton Novojilov <andy@essentialkaos.com> - 1.9.1-0
 - [cli] Fixed bug with showing current Redis version in 'info' command output
+- [cli] Improved 'stats' command output
 
 * Mon Jan 22 2024 Anton Novojilov <andy@essentialkaos.com> - 1.9.0-0
 - [cli] Improved settings info rendering

--- a/common/rds.spec
+++ b/common/rds.spec
@@ -188,6 +188,7 @@ systemctl daemon-reload &>/dev/null || :
 %changelog
 * Tue Jan 23 2024 Anton Novojilov <andy@essentialkaos.com> - 1.10.0-0
 - [cli] Fixed bug with showing current Redis version in 'info' command output
+- [cli] [sync] Send info about command initiator
 - [cli] Improved 'stats' command output
 - [cli] Added pager usage configuration to user preferences
 

--- a/common/rds.spec
+++ b/common/rds.spec
@@ -10,7 +10,7 @@
 
 Summary:        Redis orchestration tool
 Name:           rds
-Version:        1.9.1
+Version:        1.10.0
 Release:        0%{?dist}
 Group:          Applications/System
 License:        Apache License, Version 2.0
@@ -36,8 +36,8 @@ Tool for Redis orchestration.
 
 %package sync
 Summary:   RDS Sync daemon
-Version:   1.3.3
-Release:   1%{?dist}
+Version:   1.3.4
+Release:   0%{?dist}
 Group:     Applications/System
 
 Requires:  %{name}
@@ -186,9 +186,10 @@ systemctl daemon-reload &>/dev/null || :
 ################################################################################
 
 %changelog
-* Tue Jan 23 2024 Anton Novojilov <andy@essentialkaos.com> - 1.9.1-0
+* Tue Jan 23 2024 Anton Novojilov <andy@essentialkaos.com> - 1.10.0-0
 - [cli] Fixed bug with showing current Redis version in 'info' command output
 - [cli] Improved 'stats' command output
+- [cli] Added pager usage configuration to user preferences
 
 * Mon Jan 22 2024 Anton Novojilov <andy@essentialkaos.com> - 1.9.0-0
 - [cli] Improved settings info rendering

--- a/common/rds.spec
+++ b/common/rds.spec
@@ -10,7 +10,7 @@
 
 Summary:        Redis orchestration tool
 Name:           rds
-Version:        1.9.0
+Version:        1.9.1
 Release:        0%{?dist}
 Group:          Applications/System
 License:        Apache License, Version 2.0
@@ -37,7 +37,7 @@ Tool for Redis orchestration.
 %package sync
 Summary:   RDS Sync daemon
 Version:   1.3.3
-Release:   0%{?dist}
+Release:   1%{?dist}
 Group:     Applications/System
 
 Requires:  %{name}
@@ -186,6 +186,9 @@ systemctl daemon-reload &>/dev/null || :
 ################################################################################
 
 %changelog
+* Tue Jan 23 2024 Anton Novojilov <andy@essentialkaos.com> - 1.9.1-0
+- [cli] Fixed bug with showing current Redis version in 'info' command output
+
 * Mon Jan 22 2024 Anton Novojilov <andy@essentialkaos.com> - 1.9.0-0
 - [cli] Improved settings info rendering
 - [cli] UI improvements

--- a/core/core.go
+++ b/core/core.go
@@ -414,7 +414,7 @@ type sentinelConfigData struct {
 // ////////////////////////////////////////////////////////////////////////////////// //
 
 var (
-	ErrUnprivileged              = errors.New("RDS core requires root privileges")
+	ErrUnprivileged              = errors.New("RDS requires root privileges")
 	ErrSUAuthAlreadyExist        = errors.New("Superuser credentials already generated")
 	ErrSUAuthIsEmpty             = errors.New("Superuser auth data can't be empty")
 	ErrSUAuthNoData              = errors.New("Superuser auth data doesn't exist")
@@ -552,7 +552,11 @@ func (s State) WithErrors() bool {
 func Init(conf string) []error {
 	var err error
 
-	User, _ = system.CurrentUser()
+	User, err = system.CurrentUser()
+
+	if err != nil {
+		return []error{fmt.Errorf("Can't get current user info: %w", err)}
+	}
 
 	if User.UID != 0 {
 		return []error{ErrUnprivileged}

--- a/core/core.go
+++ b/core/core.go
@@ -56,7 +56,7 @@ import (
 // ////////////////////////////////////////////////////////////////////////////////// //
 
 // VERSION is current core version
-const VERSION = "A1"
+const VERSION = "A2"
 
 // META_VERSION is current meta version
 const META_VERSION = 1
@@ -336,13 +336,15 @@ type StatsClients struct {
 }
 
 type StatsMemory struct {
-	SystemMemory  uint64 `json:"system_memory"`
-	SystemSwap    uint64 `json:"system_swap"`
-	UsedMemory    uint64 `json:"used_memory"`
-	UsedMemoryRSS uint64 `json:"used_memory_rss"`
-	UsedMemoryLua uint64 `json:"used_memory_lua"`
-	UsedSwap      uint64 `json:"used_swap"`
-	IsSwapEnabled bool   `json:"is_swap_enabled"`
+	TotalSystemMemory uint64 `json:"total_system_memory"`
+	SystemMemory      uint64 `json:"system_memory"`
+	TotalSystemSwap   uint64 `json:"total_system_swap"`
+	SystemSwap        uint64 `json:"system_swap"`
+	UsedMemory        uint64 `json:"used_memory"`
+	UsedMemoryRSS     uint64 `json:"used_memory_rss"`
+	UsedMemoryLua     uint64 `json:"used_memory_lua"`
+	UsedSwap          uint64 `json:"used_swap"`
+	IsSwapEnabled     bool   `json:"is_swap_enabled"`
 }
 
 type StatsOverall struct {
@@ -2213,8 +2215,6 @@ func GetStats() *Stats {
 	var mappings = map[string]*uint64{
 		"Clients:connected_clients":        &stats.Clients.Connected,
 		"Clients:blocked_clients":          &stats.Clients.Blocked,
-		"Memory:system_memory":             &stats.Memory.SystemMemory,
-		"Memory:system_swap":               &stats.Memory.SystemSwap,
 		"Memory:used_memory":               &stats.Memory.UsedMemory,
 		"Memory:used_memory_rss":           &stats.Memory.UsedMemoryRSS,
 		"Memory:used_memory_lua":           &stats.Memory.UsedMemoryLua,
@@ -2234,7 +2234,9 @@ func GetStats() *Stats {
 
 	memUsage, _ := system.GetMemUsage()
 
+	stats.Memory.TotalSystemMemory = memUsage.MemTotal
 	stats.Memory.SystemMemory = memUsage.MemUsed
+	stats.Memory.TotalSystemSwap = memUsage.SwapTotal
 	stats.Memory.SystemSwap = memUsage.SwapUsed
 	stats.Memory.IsSwapEnabled = memUsage.SwapTotal != 0
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/essentialkaos/depsy v1.1.0
-	github.com/essentialkaos/ek/v12 v12.96.1
+	github.com/essentialkaos/ek/v12 v12.97.0
 	github.com/essentialkaos/go-linenoise/v3 v3.4.0
 	github.com/essentialkaos/redy/v4 v4.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/essentialkaos/check v1.4.0 h1:kWdFxu9odCxUqo1NNFNJmguGrDHgwi3A8daXX1nkuKk=
 github.com/essentialkaos/depsy v1.1.0 h1:U6dp687UkQwXlZU17Hg2KMxbp3nfZAoZ8duaeUFYvJI=
 github.com/essentialkaos/depsy v1.1.0/go.mod h1:kpiTAV17dyByVnrbNaMcZt2jRwvuXClUYOzpyJQwtG8=
-github.com/essentialkaos/ek/v12 v12.96.1 h1:SJQGETAJYcV88MphxxdRHy9jNGacUeTksBnoMlXy5z0=
-github.com/essentialkaos/ek/v12 v12.96.1/go.mod h1:peB5w8zUkRuDs7m/QG5Z2gMmqzSIs2viAmxzzNFIIoo=
+github.com/essentialkaos/ek/v12 v12.97.0 h1:089Kg0OmKhCZi/f4DRrloAUV+yXz+5biXvKZu/sSvAg=
+github.com/essentialkaos/ek/v12 v12.97.0/go.mod h1:peB5w8zUkRuDs7m/QG5Z2gMmqzSIs2viAmxzzNFIIoo=
 github.com/essentialkaos/go-linenoise/v3 v3.4.0 h1:g72w8x+/HIwOMBVvNaPYp+wMWVHrYZwzFAF7OfZR5Ts=
 github.com/essentialkaos/go-linenoise/v3 v3.4.0/go.mod h1:t1kNLY2bSMQCy1JXOefD2BDLs/TTPMtTv3DFNV5uDSI=
 github.com/essentialkaos/redy/v4 v4.4.0 h1:6r6AkZiDkFWPqnvl0M+u7mcaaWQaeeiZOoLqLAMcnzQ=

--- a/sync/client/sync_client.go
+++ b/sync/client/sync_client.go
@@ -32,9 +32,10 @@ func PropagateCommand(command API.MasterCommand, id int, uuid string) error {
 		ContentType: req.CONTENT_TYPE_JSON,
 		AutoDiscard: true,
 		Body: &API.PushRequest{
-			Command: command,
-			ID:      id,
-			UUID:    uuid,
+			Command:   command,
+			ID:        id,
+			UUID:      uuid,
+			Initiator: CORE.User.RealName,
 		},
 	}.Post()
 

--- a/sync/master/master.go
+++ b/sync/master/master.go
@@ -27,6 +27,7 @@ import (
 	"github.com/essentialkaos/ek/v12/mathutil"
 	"github.com/essentialkaos/ek/v12/netutil"
 	"github.com/essentialkaos/ek/v12/sortutil"
+	"github.com/essentialkaos/ek/v12/strutil"
 	"github.com/essentialkaos/ek/v12/timeutil"
 
 	API "github.com/essentialkaos/rds/api"
@@ -386,12 +387,12 @@ func pushHandler(w http.ResponseWriter, r *http.Request) {
 	if req.ID == -1 {
 		log.Info(
 			"Received push command (command: %s | initiator: %s)",
-			req.Command, req.Initiator,
+			req.Command, strutil.Q(req.Initiator, "—"),
 		)
 	} else {
 		log.Info(
 			"Received push command (command: %s | initiator: %s | ID: %d | UUID: %s)",
-			req.Command, req.Initiator, req.ID, req.UUID,
+			req.Command, strutil.Q(req.Initiator, "—"), req.ID, req.UUID,
 		)
 	}
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	APP  = "RDS Sync"
-	VER  = "1.3.3"
+	VER  = "1.3.4"
 	DESC = "Syncing daemon for RDS"
 )
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	APP  = "RDS Sync"
-	VER  = "1.3.2"
+	VER  = "1.3.3"
 	DESC = "Syncing daemon for RDS"
 )
 


### PR DESCRIPTION
#### New Features
- `[cli]` `[sync]` Send info about command initiator

#### Improvements
- `[cli]` Improved `stats` command output
- `[cli]` Added pager usage configuration to user preferences

#### Bugfixes
- `[cli]` Fixed bug with showing current Redis version in `info` command output