### PR TITLE
Version 1.10.1

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -456,6 +456,8 @@ func initCommands() {
 	isSentinelFailover := CORE.IsFailoverMethod(CORE.FAILOVER_METHOD_SENTINEL)
 	allowCommands := CORE.Config.GetB(CORE.REPLICATION_ALLOW_COMMANDS)
 
+	commands[COMMAND_GO] = &CommandRoutine{GoCommand, AUTH_NO, true}
+
 	if isMaster {
 		commands[COMMAND_START] = &CommandRoutine{StartCommand, AUTH_INSTANCE | AUTH_SUPERUSER, true}
 		commands[COMMAND_STOP] = &CommandRoutine{StopCommand, AUTH_INSTANCE | AUTH_SUPERUSER, true}
@@ -489,7 +491,6 @@ func initCommands() {
 	}
 
 	if isMaster {
-		commands[COMMAND_GO] = &CommandRoutine{GoCommand, AUTH_NO, true}
 		commands[COMMAND_CREATE] = &CommandRoutine{CreateCommand, AUTH_NO, true}
 		commands[COMMAND_DESTROY] = &CommandRoutine{DestroyCommand, AUTH_INSTANCE | AUTH_SUPERUSER | AUTH_STRICT, true}
 		commands[COMMAND_EDIT] = &CommandRoutine{EditCommand, AUTH_INSTANCE | AUTH_SUPERUSER | AUTH_STRICT, true}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -456,8 +456,6 @@ func initCommands() {
 	isSentinelFailover := CORE.IsFailoverMethod(CORE.FAILOVER_METHOD_SENTINEL)
 	allowCommands := CORE.Config.GetB(CORE.REPLICATION_ALLOW_COMMANDS)
 
-	commands[COMMAND_GO] = &CommandRoutine{GoCommand, AUTH_NO, true}
-
 	if isMaster {
 		commands[COMMAND_START] = &CommandRoutine{StartCommand, AUTH_INSTANCE | AUTH_SUPERUSER, true}
 		commands[COMMAND_STOP] = &CommandRoutine{StopCommand, AUTH_INSTANCE | AUTH_SUPERUSER, true}
@@ -531,6 +529,7 @@ func initCommands() {
 	}
 
 	if !isSentinel {
+		commands[COMMAND_GO] = &CommandRoutine{GoCommand, AUTH_NO, true}
 		commands[COMMAND_INFO] = &CommandRoutine{InfoCommand, AUTH_NO, options.GetS(OPT_FORMAT) == "" && !useRawOutput}
 		commands[COMMAND_CLIENTS] = &CommandRoutine{ClientsCommand, AUTH_NO, true}
 		commands[COMMAND_STATS_COMMAND] = &CommandRoutine{StatsCommandCommand, AUTH_NO, true}

--- a/cli/command_log.go
+++ b/cli/command_log.go
@@ -100,24 +100,21 @@ func readLogFile(logFile string, isRedisLog bool) error {
 		fd.Seek(-1*mathutil.Min(fs, 4096), 2)
 	}
 
+	lastPrint := time.Now()
 	r := bufio.NewReader(fd)
-
-	var counter int
 
 	for {
 		line, err := r.ReadString('\n')
 
 		if err != nil {
 			time.Sleep(250 * time.Millisecond)
-			counter++
 			continue
 		}
 
 		line = strings.TrimRight(line, "\r\n")
 
-		if counter > 240 { // 250ms * 4 * 60 = 1 minute
+		if time.Since(lastPrint) > time.Minute {
 			fmtutil.Separator(true)
-			counter = 0
 		}
 
 		if isRedisLog {
@@ -125,6 +122,8 @@ func readLogFile(logFile string, isRedisLog bool) error {
 		} else {
 			printRDSLogLine(line)
 		}
+
+		lastPrint = time.Now()
 	}
 }
 

--- a/common/rds.spec
+++ b/common/rds.spec
@@ -10,7 +10,7 @@
 
 Summary:        Redis orchestration tool
 Name:           rds
-Version:        1.10.0
+Version:        1.10.1
 Release:        0%{?dist}
 Group:          Applications/System
 License:        Apache License, Version 2.0
@@ -37,7 +37,7 @@ Tool for Redis orchestration.
 %package sync
 Summary:   RDS Sync daemon
 Version:   1.3.4
-Release:   0%{?dist}
+Release:   1%{?dist}
 Group:     Applications/System
 
 Requires:  %{name}
@@ -186,6 +186,10 @@ systemctl daemon-reload &>/dev/null || :
 ################################################################################
 
 %changelog
+* Fri Jan 26 2024 Anton Novojilov <andy@essentialkaos.com> - 1.10.1-0
+- [cli] Fixed bug with printing separator in 'log' output
+- [cli] Allow to run 'go' command on minions
+
 * Tue Jan 23 2024 Anton Novojilov <andy@essentialkaos.com> - 1.10.0-0
 - [cli] Fixed bug with showing current Redis version in 'info' command output
 - [cli] [sync] Send info about command initiator


### PR DESCRIPTION
#### Improvements
- `[cli]` Allow to run `go` command on minions

#### Bugfixes
- `[cli]` Fixed bug with printing separator in `log` output
